### PR TITLE
Add Linux build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,10 +60,28 @@ jobs:
           name: Windows-rbx-studio-mcp
           path: output/rbx-studio-mcp.exe
 
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: |
+          cargo install cargo-edit
+          cargo set-version --workspace "$CARGO_PKG_VERSION"
+          cargo build --release
+          mkdir -p output
+          cp target/release/rbx-studio-mcp output/
+          cd output && zip rbx-studio-mcp-linux.zip rbx-studio-mcp
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Linux-rbx-studio-mcp
+          path: output/rbx-studio-mcp-linux.zip
+
   release:
     runs-on: ubuntu-latest
     if:  ${{ github.ref_name == github.event.repository.default_branch }}
-    needs: [build-macos, build-windows]
+    needs: [build-macos, build-windows, build-linux]
     steps:
       - run: mkdir -p output
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
- Conditionally compile install module for Windows/macOS only
- Show helpful message on Linux when run without flags
- Add build-linux job to GitHub Actions workflow
- Include Linux binary in release artifacts
- Add --http-only flag for standalone HTTP server mode (no MCP stdio)

Build and runs successfully for me.  You can find a successful build here: https://github.com/dnouri/studio-rust-mcp-server/actions/runs/20539823336