### PR TITLE
feat: add run_server_code tool for server context execution

### DIFF
--- a/MCPServerCodeRunner.lua
+++ b/MCPServerCodeRunner.lua
@@ -1,0 +1,242 @@
+--[[
+	MCPServerCodeRunner - Server-side code execution for MCP testing
+
+	This script enables Claude/MCP to execute Luau code in the SERVER context during playtest.
+	Unlike run_code (which runs in the plugin context), this runs where ServerScriptService
+	scripts execute, giving access to server-side state like _G values, DataStores, etc.
+
+	SETUP:
+	1. Copy this script into ServerScriptService in your Roblox game
+	2. Enable HttpService: Game Settings > Security > Allow HTTP Requests
+	3. The script will automatically poll the MCP server for code to execute
+	4. Use the run_server_code MCP tool to execute code
+
+	BUILT-IN COMMANDS (work without loadstring):
+	- "STOP" - Stops the playtest (calls StudioTestService:EndTest)
+	- "PING" - Returns "pong" to verify the script is running
+	- "PLAYERS" - Returns list of current players
+
+	ARBITRARY CODE EXECUTION (requires LoadStringEnabled):
+	If you need to run arbitrary Luau code, you must enable loadstring:
+	1. In Explorer, click ServerScriptService
+	2. In Properties panel, find "LoadStringEnabled"
+	3. Check the checkbox to enable it
+	Note: This makes the game more vulnerable to exploits (only use in development)
+
+	SECURITY NOTE:
+	This script should ONLY be used during local development and testing.
+	Do NOT include this in published games.
+
+	EXAMPLE USAGE (from Claude/MCP):
+	run_server_code({ code = "STOP" })  -- Built-in: stops playtest
+	run_server_code({ code = "PING" })  -- Built-in: returns "pong"
+	run_server_code({ code = "PLAYERS" })  -- Built-in: lists players
+	run_server_code({ code = "return _G.GameState" })  -- Requires LoadStringEnabled
+]]
+
+local HttpService = game:GetService("HttpService")
+local RunService = game:GetService("RunService")
+local Players = game:GetService("Players")
+
+-- Configuration
+local MCP_SERVER_URL = "http://localhost:44755"
+local POLL_INTERVAL = 0.5 -- Poll every 500ms (avoid rate limiting)
+local DEBUG_MODE = true -- Set to false to reduce output
+
+local function log(...)
+	if DEBUG_MODE then
+		print("[MCPServerCodeRunner]", ...)
+	end
+end
+
+local function warn_log(...)
+	warn("[MCPServerCodeRunner]", ...)
+end
+
+-- Check if loadstring is available
+local loadstringEnabled = false
+pcall(function()
+	local test = loadstring("return true")
+	if test and test() then
+		loadstringEnabled = true
+	end
+end)
+
+-- Built-in commands that work without loadstring
+local builtInCommands = {
+	["STOP"] = function()
+		local StudioTestService = game:GetService("StudioTestService")
+		StudioTestService:EndTest("Stopped via MCP")
+		return true, "Playtest stopped"
+	end,
+
+	["PING"] = function()
+		return true, "pong"
+	end,
+
+	["PLAYERS"] = function()
+		local count = #Players:GetPlayers()
+		local names = {}
+		for _, p in Players:GetPlayers() do
+			table.insert(names, p.Name)
+		end
+		return true, "Players: " .. count .. " - " .. table.concat(names, ", ")
+	end,
+
+	["STATE"] = function()
+		return true, HttpService:JSONEncode({
+			isServer = RunService:IsServer(),
+			isRunning = RunService:IsRunning(),
+			loadstringEnabled = loadstringEnabled,
+			playerCount = #Players:GetPlayers(),
+		})
+	end,
+}
+
+-- Poll for pending server code commands
+local function pollForCode()
+	local success, response = pcall(function()
+		return HttpService:GetAsync(MCP_SERVER_URL .. "/mcp/server_code")
+	end)
+
+	if not success then
+		-- Silently fail - MCP server may not be running
+		return nil
+	end
+
+	local data = HttpService:JSONDecode(response)
+	return data.commands
+end
+
+-- Execute code and return result
+local function executeCode(code: string): (boolean, string?)
+	-- Check for built-in commands first (case-insensitive)
+	local upperCode = string.upper(string.match(code, "^%s*(.-)%s*$") or "")
+	if builtInCommands[upperCode] then
+		return builtInCommands[upperCode]()
+	end
+
+	-- Try loadstring for arbitrary code
+	if not loadstringEnabled then
+		return false, "loadstring not enabled. Use built-in commands (STOP, PING, PLAYERS, STATE) or enable LoadStringEnabled in ServerScriptService Properties panel."
+	end
+
+	-- Wrap code to capture return value
+	local wrappedCode = [[
+		local __result = (function()
+			]] .. code .. [[
+		end)()
+		return __result
+	]]
+
+	local func, compileError = loadstring(wrappedCode)
+	if not func then
+		return false, "Compile error: " .. tostring(compileError)
+	end
+
+	-- Set environment to allow access to game globals
+	setfenv(func, setmetatable({}, {
+		__index = function(_, key)
+			-- Allow access to common globals
+			return _G[key] or getfenv(0)[key]
+		end,
+		__newindex = function(_, key, value)
+			_G[key] = value
+		end
+	}))
+
+	local success, result = pcall(func)
+	if not success then
+		return false, "Runtime error: " .. tostring(result)
+	end
+
+	-- Convert result to string for return
+	local resultStr
+	if result == nil then
+		resultStr = "nil"
+	elseif type(result) == "table" then
+		-- Try to encode as JSON, fall back to tostring
+		local encodeSuccess, encoded = pcall(function()
+			return HttpService:JSONEncode(result)
+		end)
+		if encodeSuccess then
+			resultStr = encoded
+		else
+			resultStr = tostring(result)
+		end
+	else
+		resultStr = tostring(result)
+	end
+
+	return true, resultStr
+end
+
+-- Send result back to MCP server
+local function sendResult(id: string, success: boolean, result: string?, error: string?)
+	local payload = HttpService:JSONEncode({
+		id = id,
+		success = success,
+		result = result,
+		error = error,
+	})
+
+	local httpSuccess, httpError = pcall(function()
+		HttpService:PostAsync(
+			MCP_SERVER_URL .. "/mcp/server_code",
+			payload,
+			Enum.HttpContentType.ApplicationJson
+		)
+	end)
+
+	if not httpSuccess then
+		warn_log("Failed to send result:", httpError)
+	end
+end
+
+-- Process a single code command
+local function processCommand(command)
+	log("Executing code (id: " .. command.id .. "):")
+	if DEBUG_MODE then
+		print("---")
+		print(command.code)
+		print("---")
+	end
+
+	local success, result = executeCode(command.code)
+
+	if success then
+		log("Success:", result)
+		sendResult(command.id, true, result, nil)
+	else
+		warn_log("Error:", result)
+		sendResult(command.id, false, nil, result)
+	end
+end
+
+-- Main polling loop
+local function startPolling()
+	log("Started - polling", MCP_SERVER_URL, "for server code commands")
+	log("Server context: RunService:IsServer() =", RunService:IsServer())
+	log("loadstring enabled:", loadstringEnabled)
+	log("Built-in commands: STOP, PING, PLAYERS, STATE")
+
+	while true do
+		local commands = pollForCode()
+
+		if commands and #commands > 0 then
+			for _, command in ipairs(commands) do
+				processCommand(command)
+			end
+		end
+
+		task.wait(POLL_INTERVAL)
+	end
+end
+
+-- Only run on server
+if RunService:IsServer() then
+	-- Delay slightly to let other scripts initialize first
+	task.delay(0.5, startPolling)
+else
+	warn_log("This script must run on the server (ServerScriptService)")
+end

--- a/README.md
+++ b/README.md
@@ -104,3 +104,29 @@ sometimes is hidden in the system tray, so ensure you've exited it completely.
 1. Type a prompt in Claude Desktop and accept any permissions to communicate with Studio.
 1. Verify that the intended action is performed in Studio by checking the console, inspecting the
    data model in Explorer, or visually confirming the desired changes occurred in your place.
+
+## Available Tools
+
+### run_code
+Executes Luau code in the Studio plugin context and returns printed output.
+
+### insert_model
+Searches the Roblox marketplace and inserts a model into the workspace.
+
+### run_server_code
+Executes Luau code in the **server context** during playtest. Unlike `run_code` which runs in the plugin, this runs where ServerScriptService scripts execute.
+
+**Setup Required:**
+1. Copy `MCPServerCodeRunner.lua` to ServerScriptService in your game
+2. Enable HttpService: Game Settings > Security > Allow HTTP Requests
+3. Start playtest (F5)
+
+**Built-in Commands** (work without LoadStringEnabled):
+- `"PING"` - Returns "pong" to verify the script is running
+- `"PLAYERS"` - Returns list of current players
+- `"STATE"` - Returns server state info
+- `"STOP"` - Stops the playtest
+
+**Arbitrary Code** requires enabling LoadStringEnabled in ServerScriptService properties.
+
+**Example prompt:** "Check if the game server is running" (uses PING command)

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,8 @@ async fn main() -> Result<()> {
             .route("/request", get(request_handler))
             .route("/response", post(response_handler))
             .route("/proxy", post(proxy_handler))
+            .route("/mcp/server_code", get(get_server_code_handler))
+            .route("/mcp/server_code", post(post_server_code_result_handler))
             .with_state(server_state_clone);
         tracing::info!("This MCP instance is HTTP server listening on {STUDIO_PLUGIN_PORT}");
         tokio::spawn(async {

--- a/src/rbx_studio_server.rs
+++ b/src/rbx_studio_server.rs
@@ -21,6 +21,9 @@ use uuid::Uuid;
 pub const STUDIO_PLUGIN_PORT: u16 = 44755;
 const LONG_POLL_DURATION: Duration = Duration::from_secs(15);
 
+// Timeout for waiting for server code execution result
+const SERVER_CODE_TIMEOUT: Duration = Duration::from_secs(30);
+
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct ToolArguments {
     args: ToolArgumentValues,
@@ -33,11 +36,39 @@ pub struct RunCommandResponse {
     id: Uuid,
 }
 
+/// Command for server-side code execution - queued by MCP, polled by game ServerScript
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ServerCodeCommand {
+    pub id: Uuid,
+    pub code: String,
+    pub timestamp: u64,
+}
+
+/// Result from server-side code execution
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ServerCodeResult {
+    pub id: Uuid,
+    pub success: bool,
+    pub result: Option<String>,
+    pub error: Option<String>,
+}
+
+/// Response for GET /mcp/server_code - list of pending commands
+#[derive(Debug, Serialize)]
+pub struct ServerCodePollResponse {
+    pub commands: Vec<ServerCodeCommand>,
+    pub count: usize,
+}
+
 pub struct AppState {
     process_queue: VecDeque<ToolArguments>,
     output_map: HashMap<Uuid, mpsc::UnboundedSender<Result<String>>>,
     waiter: watch::Receiver<()>,
     trigger: watch::Sender<()>,
+    /// Queue of server code commands for game to poll
+    pub server_code_queue: VecDeque<ServerCodeCommand>,
+    /// Map of pending server code result channels (waiting for game to respond)
+    pub server_code_results: HashMap<Uuid, mpsc::UnboundedSender<ServerCodeResult>>,
 }
 pub type PackedState = Arc<Mutex<AppState>>;
 
@@ -49,6 +80,8 @@ impl AppState {
             output_map: HashMap::new(),
             waiter,
             trigger,
+            server_code_queue: VecDeque::new(),
+            server_code_results: HashMap::new(),
         }
     }
 }
@@ -68,6 +101,7 @@ impl ToolArguments {
         )
     }
 }
+
 #[derive(Clone)]
 pub struct RBXStudioServer {
     state: PackedState,
@@ -100,6 +134,7 @@ struct RunCode {
     #[schemars(description = "Code to run")]
     command: String,
 }
+
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone)]
 struct InsertModel {
     #[schemars(description = "Query to search for the model")]
@@ -107,10 +142,17 @@ struct InsertModel {
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone)]
+struct RunServerCode {
+    #[schemars(description = "Luau code to execute in the server context during playtest")]
+    code: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone)]
 enum ToolArgumentValues {
     RunCode(RunCode),
     InsertModel(InsertModel),
 }
+
 #[tool_router]
 impl RBXStudioServer {
     pub fn new(state: PackedState) -> Self {
@@ -140,6 +182,76 @@ impl RBXStudioServer {
     ) -> Result<CallToolResult, ErrorData> {
         self.generic_tool_run(ToolArgumentValues::InsertModel(args))
             .await
+    }
+
+    #[tool(
+        description = "Executes Luau code in the server context during playtest. Unlike run_code which executes in the plugin context, this runs in the actual game server where ServerScriptService scripts execute. Requires MCPServerCodeRunner script in ServerScriptService. Use this to: verify server-side state, test game logic, check _G values set by server scripts, or invoke server functions."
+    )]
+    async fn run_server_code(
+        &self,
+        Parameters(args): Parameters<RunServerCode>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let command_id = Uuid::new_v4();
+        let command = ServerCodeCommand {
+            id: command_id,
+            code: args.code.clone(),
+            timestamp: current_timestamp_ms(),
+        };
+
+        // Create channel to receive result
+        let (tx, mut rx) = mpsc::unbounded_channel::<ServerCodeResult>();
+
+        // Queue the command and register for result
+        {
+            let mut state = self.state.lock().await;
+            state.server_code_queue.push_back(command);
+            state.server_code_results.insert(command_id, tx);
+        }
+
+        // Wait for result with timeout
+        let result = match tokio::time::timeout(SERVER_CODE_TIMEOUT, rx.recv()).await {
+            Ok(Some(result)) => result,
+            Ok(None) => {
+                // Channel closed without response
+                let mut state = self.state.lock().await;
+                state.server_code_results.remove(&command_id);
+                return Ok(CallToolResult::error(vec![Content::text(
+                    "Server code execution channel closed unexpectedly. Is the MCPServerCodeRunner script running?",
+                )]));
+            }
+            Err(_) => {
+                // Timeout elapsed
+                let mut state = self.state.lock().await;
+                state.server_code_results.remove(&command_id);
+                return Ok(CallToolResult::error(vec![Content::text(format!(
+                    "Server code execution timed out after {}s. Ensure:\n\
+                    1. Studio is in playtest mode (F5)\n\
+                    2. MCPServerCodeRunner script is in ServerScriptService\n\
+                    3. HttpService is enabled (Game Settings > Security > Allow HTTP Requests)\n\
+                    4. The script is polling http://localhost:{}/mcp/server_code",
+                    SERVER_CODE_TIMEOUT.as_secs(),
+                    STUDIO_PLUGIN_PORT
+                ))]));
+            }
+        };
+
+        // Clean up
+        {
+            let mut state = self.state.lock().await;
+            state.server_code_results.remove(&command_id);
+        }
+
+        // Return result
+        if result.success {
+            Ok(CallToolResult::success(vec![Content::text(
+                result.result.unwrap_or_else(|| "nil".to_string()),
+            )]))
+        } else {
+            Ok(CallToolResult::error(vec![Content::text(format!(
+                "Server code error: {}",
+                result.error.unwrap_or_else(|| "Unknown error".to_string())
+            ))]))
+        }
     }
 
     async fn generic_tool_run(
@@ -172,6 +284,15 @@ impl RBXStudioServer {
             Err(err) => Ok(CallToolResult::error(vec![Content::text(err.to_string())])),
         }
     }
+}
+
+/// Helper to get current timestamp in milliseconds
+fn current_timestamp_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 pub async fn request_handler(State(state): State<PackedState>) -> Result<impl IntoResponse> {
@@ -261,5 +382,32 @@ pub async fn dud_proxy_loop(state: PackedState, exit: Receiver<()>) {
         } else {
             waiter.changed().await.unwrap();
         }
+    }
+}
+
+/// Handler for GET /mcp/server_code - Game ServerScript polls for pending code commands
+pub async fn get_server_code_handler(
+    State(state): State<PackedState>,
+) -> impl IntoResponse {
+    let mut state = state.lock().await;
+    let commands: Vec<ServerCodeCommand> = state.server_code_queue.drain(..).collect();
+    let count = commands.len();
+    Json(ServerCodePollResponse { commands, count })
+}
+
+/// Handler for POST /mcp/server_code - Game ServerScript posts execution results here
+pub async fn post_server_code_result_handler(
+    State(state): State<PackedState>,
+    Json(result): Json<ServerCodeResult>,
+) -> impl IntoResponse {
+    let mut state = state.lock().await;
+    if let Some(tx) = state.server_code_results.remove(&result.id) {
+        if tx.send(result).is_err() {
+            tracing::warn!("Failed to send server code result - receiver dropped");
+        }
+        (StatusCode::OK, "OK")
+    } else {
+        tracing::warn!("Received server code result for unknown id: {}", result.id);
+        (StatusCode::NOT_FOUND, "Unknown command ID")
     }
 }


### PR DESCRIPTION
## Summary
Adds new MCP tool to execute Luau code in the actual game server context during playtest, unlike `run_code` which executes in the plugin context.

## Motivation
Currently, `run_code` executes in the plugin's Lua context, which is isolated from server-side game state during playtest. This means you can't:
- Verify if server scripts initialized properly
- Check `_G` values set by ServerScriptService scripts
- Test server-side functionality

This PR adds `run_server_code` which executes in the actual game server context.

## New Tool: run_server_code

```
run_server_code({ code: "PING" })
run_server_code({ code: "return _G.PlayerDataStore" })  -- requires LoadStringEnabled
```

## Architecture
- MCP server queues code commands at `/mcp/server_code` endpoint
- Game ServerScript (`MCPServerCodeRunner.lua`) polls for pending code
- Script executes code and POSTs results back
- Tool waits with 30s timeout

## Setup
1. Copy `MCPServerCodeRunner.lua` to ServerScriptService in your game
2. Enable HttpService: Game Settings > Security > Allow HTTP Requests
3. Start playtest (F5)
4. Use the `run_server_code` tool

## Built-in Commands (work without LoadStringEnabled)
- `PING` - Returns "pong" to verify script is running
- `PLAYERS` - Returns list of current players
- `STATE` - Returns server state info as JSON
- `STOP` - Stops the playtest

## Test plan
- [x] Verify tool returns error when not in playtest
- [x] Verify tool returns error when MCPServerCodeRunner not present
- [x] Verify tool executes code and returns result (PING → pong)
- [x] Verify built-in commands work without LoadStringEnabled
- [x] Verify 30s timeout works

🤖 Generated with [Claude Code](https://claude.ai/code)