### PR TITLE
Claude code instructions

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -65,7 +65,7 @@ fn get_exe_path() -> io::Result<PathBuf> {
     env::current_exe()
 }
 
-pub fn suggest_to_config_claude_code<'a>(exe_path: &Path) -> Result<String> {
+pub fn suggest_to_config_claude_code(exe_path: &Path) -> Result<String> {
     let home_dir = env::var_os("HOME")
         .or_else(|| env::var_os("USERPROFILE"))
         .unwrap();
@@ -78,7 +78,7 @@ pub fn suggest_to_config_claude_code<'a>(exe_path: &Path) -> Result<String> {
     }
 }
 
-pub fn install_to_config<'a>(
+pub fn install_to_config(
     config_path: Result<PathBuf>,
     exe_path: &Path,
     name: &str,


### PR DESCRIPTION
since Claude doesn't have global MCP config, it prints out instructions (copy-pastable)

<img width="588" height="460" alt="image" src="https://github.com/user-attachments/assets/ccddf8f7-2415-4756-89a6-8fae07bde525" />
