### PR TITLE
feat: Add create_responsive_layout tool for UI scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,26 @@ sometimes is hidden in the system tray, so ensure you've exited it completely.
 1. Type a prompt in Claude Desktop and accept any permissions to communicate with Studio.
 1. Verify that the intended action is performed in Studio by checking the console, inspecting the
    data model in Explorer, or visually confirming the desired changes occurred in your place.
+
+## Available Tools
+
+### run_code
+Executes Luau code in the Studio plugin context and returns printed output.
+
+### insert_model
+Searches the Roblox marketplace and inserts a model into the workspace.
+
+### create_responsive_layout
+Creates a ScreenGui with best-practice responsive container structure.
+
+**Parameters:**
+- `name`: Name for the ScreenGui (e.g., `"MainUI"`)
+- `containers`: Array of positions: `"TopLeft"`, `"TopRight"`, `"TopCenter"`, `"BottomLeft"`, `"BottomRight"`, `"BottomCenter"`, `"CenterLeft"`, `"CenterRight"`, `"Center"`
+
+**Each container includes:**
+- Correct `AnchorPoint` and `Position` for its location
+- `UISizeConstraint` (Min 100x50, Max 400x600)
+- `UIListLayout` for automatic child arrangement
+- `UIPadding` for internal spacing
+
+**Example prompt:** "Create a responsive UI with containers in the top-left and bottom-center"

--- a/plugin/src/Tools/CreateResponsiveLayout.luau
+++ b/plugin/src/Tools/CreateResponsiveLayout.luau
@@ -1,0 +1,167 @@
+local Main = script:FindFirstAncestor("MCPStudioPlugin")
+local Types = require(Main.Types)
+
+local StarterGui = game:GetService("StarterGui")
+
+type CreateResponsiveLayoutArgs = {
+	name: string,
+	containers: {string},
+}
+
+-- Container configurations: AnchorPoint, Position, default name suffix
+local CONTAINER_CONFIGS = {
+	TopLeft = {
+		anchor = Vector2.new(0, 0),
+		position = UDim2.new(0, 8, 0, 8),
+		suffix = "TopLeft"
+	},
+	TopRight = {
+		anchor = Vector2.new(1, 0),
+		position = UDim2.new(1, -8, 0, 8),
+		suffix = "TopRight"
+	},
+	TopCenter = {
+		anchor = Vector2.new(0.5, 0),
+		position = UDim2.new(0.5, 0, 0, 8),
+		suffix = "TopCenter"
+	},
+	BottomLeft = {
+		anchor = Vector2.new(0, 1),
+		position = UDim2.new(0, 8, 1, -8),
+		suffix = "BottomLeft"
+	},
+	BottomRight = {
+		anchor = Vector2.new(1, 1),
+		position = UDim2.new(1, -8, 1, -8),
+		suffix = "BottomRight"
+	},
+	BottomCenter = {
+		anchor = Vector2.new(0.5, 1),
+		position = UDim2.new(0.5, 0, 1, -8),
+		suffix = "BottomCenter"
+	},
+	CenterLeft = {
+		anchor = Vector2.new(0, 0.5),
+		position = UDim2.new(0, 8, 0.5, 0),
+		suffix = "CenterLeft"
+	},
+	CenterRight = {
+		anchor = Vector2.new(1, 0.5),
+		position = UDim2.new(1, -8, 0.5, 0),
+		suffix = "CenterRight"
+	},
+	Center = {
+		anchor = Vector2.new(0.5, 0.5),
+		position = UDim2.new(0.5, 0, 0.5, 0),
+		suffix = "Center"
+	},
+}
+
+local function createContainer(parent: ScreenGui, containerType: string): Frame?
+	local config = CONTAINER_CONFIGS[containerType]
+	if not config then
+		return nil
+	end
+
+	local container = Instance.new("Frame")
+	container.Name = config.suffix .. "Container"
+	container.AnchorPoint = config.anchor
+	container.Position = config.position
+	container.Size = UDim2.new(0.3, 0, 0.3, 0) -- Default 30% of screen
+	container.BackgroundTransparency = 1
+	container.BorderSizePixel = 0
+
+	-- Add UISizeConstraint for bounded sizing
+	local sizeConstraint = Instance.new("UISizeConstraint")
+	sizeConstraint.MinSize = Vector2.new(100, 50)
+	sizeConstraint.MaxSize = Vector2.new(400, 600)
+	sizeConstraint.Parent = container
+
+	-- Add UIListLayout for automatic child arrangement
+	local listLayout = Instance.new("UIListLayout")
+	listLayout.FillDirection = Enum.FillDirection.Vertical
+	listLayout.HorizontalAlignment = Enum.HorizontalAlignment.Center
+	listLayout.VerticalAlignment = Enum.VerticalAlignment.Top
+	listLayout.Padding = UDim.new(0, 8)
+	listLayout.SortOrder = Enum.SortOrder.LayoutOrder
+	listLayout.Parent = container
+
+	-- Add UIPadding for internal spacing
+	local padding = Instance.new("UIPadding")
+	padding.PaddingTop = UDim.new(0, 8)
+	padding.PaddingBottom = UDim.new(0, 8)
+	padding.PaddingLeft = UDim.new(0, 8)
+	padding.PaddingRight = UDim.new(0, 8)
+	padding.Parent = container
+
+	container.Parent = parent
+	return container
+end
+
+local function handleCreateResponsiveLayout(args: Types.ToolArgs): string?
+	if not args["CreateResponsiveLayout"] then
+		return nil
+	end
+
+	local layoutArgs: CreateResponsiveLayoutArgs = args["CreateResponsiveLayout"]
+
+	if not layoutArgs.name or layoutArgs.name == "" then
+		return "[ERROR] Missing 'name' parameter for ScreenGui"
+	end
+
+	if not layoutArgs.containers or #layoutArgs.containers == 0 then
+		return "[ERROR] Missing or empty 'containers' array. Specify positions like ['TopLeft', 'BottomCenter']"
+	end
+
+	-- Check if ScreenGui already exists
+	local existing = StarterGui:FindFirstChild(layoutArgs.name)
+	if existing then
+		return "[ERROR] ScreenGui '" .. layoutArgs.name .. "' already exists in StarterGui"
+	end
+
+	-- Validate container types
+	local invalidContainers = {}
+	for _, containerType in layoutArgs.containers do
+		if not CONTAINER_CONFIGS[containerType] then
+			table.insert(invalidContainers, containerType)
+		end
+	end
+	if #invalidContainers > 0 then
+		local validTypes = {}
+		for key in CONTAINER_CONFIGS do
+			table.insert(validTypes, key)
+		end
+		return "[ERROR] Invalid container type(s): " .. table.concat(invalidContainers, ", ") ..
+			"\nValid types: " .. table.concat(validTypes, ", ")
+	end
+
+	-- Create ScreenGui
+	local screenGui = Instance.new("ScreenGui")
+	screenGui.Name = layoutArgs.name
+	screenGui.IgnoreGuiInset = true -- Full screen coverage
+	screenGui.ResetOnSpawn = false
+	screenGui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
+
+	-- Create requested containers
+	local createdContainers = {}
+	for _, containerType in layoutArgs.containers do
+		local container = createContainer(screenGui, containerType)
+		if container then
+			table.insert(createdContainers, container.Name)
+		end
+	end
+
+	screenGui.Parent = StarterGui
+
+	local structure = layoutArgs.name .. " (ScreenGui, IgnoreGuiInset=true)\n"
+	for _, containerName in createdContainers do
+		structure = structure .. "├── " .. containerName .. "\n"
+		structure = structure .. "│   ├── UISizeConstraint (Min 100x50, Max 400x600)\n"
+		structure = structure .. "│   ├── UIListLayout (Vertical)\n"
+		structure = structure .. "│   └── UIPadding (8px)\n"
+	end
+
+	return "[SUCCESS] Created responsive layout in StarterGui:\n\n" .. structure
+end
+
+return handleCreateResponsiveLayout :: Types.ToolFunction

--- a/plugin/src/Types.luau
+++ b/plugin/src/Types.luau
@@ -6,7 +6,12 @@ export type RunCodeArgs = {
 	command: string,
 }
 
-export type ToolArgs = { InsertModel: InsertModelArgs } | { RunCode: RunCodeArgs }
+export type CreateResponsiveLayoutArgs = {
+	name: string,
+	containers: {string},
+}
+
+export type ToolArgs = { InsertModel: InsertModelArgs } | { RunCode: RunCodeArgs } | { CreateResponsiveLayout: CreateResponsiveLayoutArgs }
 
 export type ToolFunction = (ToolArgs) -> string?
 

--- a/src/rbx_studio_server.rs
+++ b/src/rbx_studio_server.rs
@@ -100,6 +100,7 @@ struct RunCode {
     #[schemars(description = "Code to run")]
     command: String,
 }
+
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone)]
 struct InsertModel {
     #[schemars(description = "Query to search for the model")]
@@ -107,9 +108,18 @@ struct InsertModel {
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone)]
+struct CreateResponsiveLayout {
+    #[schemars(description = "Name for the ScreenGui (e.g., 'MainUI')")]
+    name: String,
+    #[schemars(description = "Array of container positions to create: 'TopLeft', 'TopRight', 'TopCenter', 'BottomLeft', 'BottomRight', 'BottomCenter', 'CenterLeft', 'CenterRight', 'Center'")]
+    containers: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone)]
 enum ToolArgumentValues {
     RunCode(RunCode),
     InsertModel(InsertModel),
+    CreateResponsiveLayout(CreateResponsiveLayout),
 }
 #[tool_router]
 impl RBXStudioServer {
@@ -139,6 +149,17 @@ impl RBXStudioServer {
         Parameters(args): Parameters<InsertModel>,
     ) -> Result<CallToolResult, ErrorData> {
         self.generic_tool_run(ToolArgumentValues::InsertModel(args))
+            .await
+    }
+
+    #[tool(
+        description = "Creates a responsive UI layout with best-practice container structure. Creates a ScreenGui with positioned containers that include UISizeConstraint and UIListLayout for proper responsive behavior."
+    )]
+    async fn create_responsive_layout(
+        &self,
+        Parameters(args): Parameters<CreateResponsiveLayout>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.generic_tool_run(ToolArgumentValues::CreateResponsiveLayout(args))
             .await
     }
 


### PR DESCRIPTION
## Summary
- Adds `create_responsive_layout` tool that generates a properly structured ScreenGui with positioned containers
- Creates containers at specified positions: TopLeft, TopRight, TopCenter, BottomLeft, BottomRight, BottomCenter, CenterLeft, CenterRight, Center
- Each container includes:
  - Correct AnchorPoint/Position pairs for responsive positioning
  - UISizeConstraint (Min 100x50, Max 400x600)
  - UIListLayout for automatic child arrangement
  - UIPadding for internal spacing

## Use Cases
- Quickly scaffold responsive UI structure
- Ensure consistent UI patterns across projects
- Avoid common positioning mistakes from the start

## Test plan
- [ ] Build and install plugin
- [ ] Call `create_responsive_layout` with name and container list
- [ ] Verify ScreenGui is created in StarterGui
- [ ] Verify containers have correct positioning and constraints
- [ ] Test with various container combinations

Addresses #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)