### PR TITLE
Mcp status widget

### DIFF
--- a/plugin/src/Main.server.luau
+++ b/plugin/src/Main.server.luau
@@ -101,7 +101,7 @@ local currentClient: MockWebSocketService.MockWebSocketClient? = connectWebSocke
 print("The MCP Studio plugin is ready for prompts.")
 
 local toolbar = plugin:CreateToolbar("MCP")
-local toggleButton = toolbar:CreateButton("Toggle MCP", "Toggle connection to the server", getButtonImage())
+local toggleButton = toolbar:CreateButton("MCP Server", "Show or hide the MCP Server panel", getButtonImage())
 toggleButton.ClickableWhenViewportHidden = true
 toggleButton:SetActive(currentClient ~= nil)
 
@@ -116,31 +116,110 @@ local widgetInfo = DockWidgetPluginGuiInfo.new(
 )
 local statusWidget = plugin:CreateDockWidgetPluginGui("MCPStatus", widgetInfo)
 statusWidget.Title = "MCP Status"
+statusWidget.Enabled = true
 
 local statusLabel = Instance.new("TextLabel")
 statusLabel.BackgroundTransparency = 1
-statusLabel.Size = UDim2.fromScale(1, 1)
+statusLabel.Size = UDim2.fromScale(1, 0.55)
 statusLabel.Font = Enum.Font.SourceSansSemibold
 statusLabel.TextSize = 18
 statusLabel.TextColor3 = Color3.fromRGB(240, 240, 240)
 statusLabel.Parent = statusWidget
 
+local segmentedContainer = Instance.new("Frame")
+segmentedContainer.AnchorPoint = Vector2.new(0.5, 0.5)
+segmentedContainer.BackgroundTransparency = 1
+segmentedContainer.Position = UDim2.fromScale(0.5, 0.72)
+segmentedContainer.Size = UDim2.fromOffset(180, 28)
+segmentedContainer.Parent = statusWidget
+
+local segmentedLayout = Instance.new("UIListLayout")
+segmentedLayout.FillDirection = Enum.FillDirection.Horizontal
+segmentedLayout.HorizontalAlignment = Enum.HorizontalAlignment.Center
+segmentedLayout.VerticalAlignment = Enum.VerticalAlignment.Center
+segmentedLayout.Padding = UDim.new(0, 6)
+segmentedLayout.Parent = segmentedContainer
+
+local offButton = Instance.new("TextButton")
+offButton.Size = UDim2.fromOffset(84, 26)
+offButton.Font = Enum.Font.SourceSansSemibold
+offButton.TextSize = 14
+offButton.Text = "OFF"
+offButton.AutoButtonColor = false
+offButton.Parent = segmentedContainer
+
+local offCorner = Instance.new("UICorner")
+offCorner.CornerRadius = UDim.new(0, 7)
+offCorner.Parent = offButton
+
+local onButton = Instance.new("TextButton")
+onButton.Size = UDim2.fromOffset(84, 26)
+onButton.Font = Enum.Font.SourceSansSemibold
+onButton.TextSize = 14
+onButton.Text = "ON"
+onButton.AutoButtonColor = false
+onButton.Parent = segmentedContainer
+
+local onCorner = Instance.new("UICorner")
+onCorner.CornerRadius = UDim.new(0, 7)
+onCorner.Parent = onButton
+
+local function renderUIFromState(isServerOn: boolean)
+	if isServerOn then
+		onButton.BackgroundTransparency = 0
+		onButton.BackgroundColor3 = Color3.fromRGB(46, 160, 67)
+		onButton.TextColor3 = Color3.fromRGB(240, 240, 240)
+		onButton.Active = false
+
+		offButton.BackgroundTransparency = 0.6
+		offButton.BackgroundColor3 = Color3.fromRGB(40, 40, 40)
+		offButton.TextColor3 = Color3.fromRGB(200, 200, 200)
+		offButton.Active = true
+	else
+		offButton.BackgroundTransparency = 0
+		offButton.BackgroundColor3 = Color3.fromRGB(90, 90, 90)
+		offButton.TextColor3 = Color3.fromRGB(240, 240, 240)
+		offButton.Active = false
+
+		onButton.BackgroundTransparency = 0.6
+		onButton.BackgroundColor3 = Color3.fromRGB(40, 40, 40)
+		onButton.TextColor3 = Color3.fromRGB(200, 200, 200)
+		onButton.Active = true
+	end
+end
+
 local function updateStatus(isConnected: boolean)
-	toggleButton:SetActive(isConnected)
+	toggleButton:SetActive(statusWidget.Enabled)
 	statusLabel.Text = if isConnected then "MCP Server: ON" else "MCP Server: OFF"
+	renderUIFromState(isConnected)
 end
 
 updateStatus(currentClient ~= nil)
 
-toggleButton.Click:Connect(function()
-	if not currentClient then
+local function setConnection(isConnected: boolean)
+	if isConnected then
 		currentClient = connectWebSocket()
 		print("The MCP Studio plugin is ready for prompts.")
 		updateStatus(true)
 	else
-		currentClient:Close()
-		currentClient = nil
+		if currentClient then
+			currentClient:Close()
+			currentClient = nil
+		end
 		print("The MCP Studio plugin is stopped.")
 		updateStatus(false)
 	end
+end
+
+toggleButton.Click:Connect(function()
+	statusWidget.Enabled = not statusWidget.Enabled
+	toggleButton:SetActive(statusWidget.Enabled)
+end)
+
+offButton.MouseButton1Click:Connect(function()
+	setConnection(false)
+end)
+
+onButton.MouseButton1Click:Connect(function()
+	setConnection(true)
 end)


### PR DESCRIPTION
## Description

Adds a docked “MCP Status” panel in Studio with a segmented OFF/ON control that explicitly sets the MCP server connection state.

<img width="282" height="131" alt="image" src="https://github.com/user-attachments/assets/d82d0e5b-6d2a-4268-8495-ea5624d8dc61" />

<img width="281" height="133" alt="image" src="https://github.com/user-attachments/assets/ebe44320-851c-4bed-bff7-9c6d1065ee7e" />

## Rationale

Previously, the plugin button directly toggled the MCP server on and off, with no clear feedback beyond messages in the output terminal. Now, the plugin button controls the visibility of a dedicated panel, where it’s immediately clear whether the server is running or stopped. The terminal output is still present.

This removes ambiguity about the current server state and avoids action/state reversal

## Testing Instructions

1. Install/import the plugin in Studio.
2. Open the Plugins tab.
3. Click “MCP Server” to show/hide the panel.
4. Click OFF to stop the server, or ON to start it.
5. Confirm the Output window logs the corresponding start/stop message.

---

## Contribution Guidelines

Please ensure your PR follows these guidelines:

### Keep PRs Focused
- **Single feature per PR** - Each PR should address one specific feature, fix, or improvement
- Keep changes brief and reviewable

### For New Tools

When adding a new MCP tool, ensure it meets **all** of the following criteria:

1. **Roblox/Roblox Studio Specific** - The tool must provide functionality specific to Roblox or Roblox Studio. Generic tools (e.g., screenshotting, file operations) can be provided by many existing MCP servers and don't belong here.

2. **More Efficient Than Running Code** - The tool must be more efficient than simply running Luau code in Studio:
   - Do **not** add tools that wrap 1-2 lines of Luau code
   - Tools are announced with every request and consume context window
   - If you frequently reuse code snippets, add them to an AI instruction file instead

### Checklist

- [x] PR addresses a single feature/fix
- [x] Rationale for the change is clearly explained above
- [x] Testing instructions are provided
- [ ] (If fixing a bug) Steps to reproduce the original issue are included
- [ ] (If adding a tool) Tool is Roblox/Roblox Studio specific
- [ ] (If adding a tool) Tool provides significant value over running inline Luau code
